### PR TITLE
Fix build on GCC 14

### DIFF
--- a/utils/applymask32.c
+++ b/utils/applymask32.c
@@ -6,6 +6,7 @@
 static unsigned char g_cfg_filler = 0;
 static unsigned char used2[256];
 
+int load_mask(char *filename);
 void applyBlockMask(char *filename);
 
 int main(int argc, char **argv)


### PR DESCRIPTION
`load_mask` wasn't declared before `main`, which caused GCC to error on implicitly declared function.